### PR TITLE
Add IDP feature in Auth url

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/global.jelly
@@ -13,5 +13,9 @@
 				<f:checkbox/>
 			</f:entry>
 		</f:optionalBlock>
+        
+        <f:entry title="Use default IDP"  field="keycloakIdp" help="/plugin/keycloak/help/auth/keycloak-idp-help.html">
+            <f:textbox/>
+        </f:entry>
 	</f:section>
 </j:jelly>

--- a/src/main/webapp/help/auth/keycloak-idp-help.html
+++ b/src/main/webapp/help/auth/keycloak-idp-help.html
@@ -1,0 +1,1 @@
+<div>When an idp is specified, this idp will be used to make authentication. In fact kc_idp_hint parameter will be added in the auth url</div>


### PR DESCRIPTION
The aim of this PR is to be able to specify a default IDP that will be used by default for auth.
In fact, that adds kc_idp_hint parameter in auth url to use directly a specific IDP (if this parameter is filled in Jenkins configuration page).