### PR TITLE
Add support for pulling authorities from a "roles" claim

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/KeycloakAuthentication.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAuthentication.java
@@ -47,11 +47,19 @@ public class KeycloakAuthentication extends AbstractAuthenticationToken  {
 	private static GrantedAuthority[] buildRoles(AccessToken accessToken) {
 		List<GrantedAuthority> roles;
 		roles = new ArrayList<GrantedAuthority>();
+
 		if (accessToken != null && accessToken.getRealmAccess() != null) {
 			for (String role : accessToken.getRealmAccess().getRoles()) {
 				roles.add(new GrantedAuthorityImpl(role));
 			}
 		}
+
+		if(accessToken != null && accessToken.getOtherClaims().containsKey("roles")) {
+			for(String role : (List<String>) accessToken.getOtherClaims().get("roles")) {
+				roles.add(new GrantedAuthorityImpl(role));
+			}
+		}
+
 		roles.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
 		return roles.toArray(new GrantedAuthority[roles.size()]);
 	}


### PR DESCRIPTION
Currently to assign roles to a user within jenkins via keycloak the
role must be placed at a realm global level and full scope allowed
must be on.

This isn't idea.... it would be nice to be able to use client roles.
This commit adds support for reading roles from a claims attribute
called "roles".

A keycloak administrator can associate roles to a user using the
mappers in keycloak