### PR TITLE
Fix keycloak configure load error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin
 /update-center.key
 .factorypath
 .vscode
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<keycloak.version>13.0.0</keycloak.version>
+		<keycloak.version>12.0.0</keycloak.version>
 		<jenkins.version>2.263.1</jenkins.version>
 		<java.level>8</java.level>
 		<configuration-as-code.version>1.36</configuration-as-code.version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<keycloak.version>9.0.3</keycloak.version>
-		<jenkins.version>2.190.1</jenkins.version>
-		<log4j.version>1.7.26</log4j.version>
+		<keycloak.version>12.0.0</keycloak.version>
+		<jenkins.version>2.263.1</jenkins.version>
 		<java.level>8</java.level>
 		<configuration-as-code.version>1.36</configuration-as-code.version>
 		<jackson.version>2.12.2</jackson.version>
+		<lombok.version>1.18.20</lombok.version>
 	</properties>
 
 	<licenses>
@@ -63,6 +63,18 @@
 	  <tag>HEAD</tag>
   	</scm>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.263.x</artifactId>
+				<version>26</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.keycloak</groupId>
@@ -94,26 +106,6 @@
 			<version>1.4</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>${log4j.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 			<version>${jackson.version}</version>
@@ -123,6 +115,13 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>${lombok.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>io.jenkins</groupId>
 			<artifactId>configuration-as-code</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -384,22 +384,26 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 		}
 
 		@Override
-		public SecurityRealm newInstance(StaplerRequest req, JSONObject json) throws FormException {
-			json = json.getJSONObject("keycloak");
+		public SecurityRealm newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+
+			JSONObject keycloak = new JSONObject();
+
+			JSONObject keycloakData = formData.getJSONObject("keycloak");
+			keycloak.putAll(keycloakData);
 			// if json contains keycloakvalidate then keycloakvalidate is true
-			if (json.containsKey("keycloakValidate")) {
+			if (keycloakData.containsKey("keycloakValidate")) {
 				LOGGER.log(Level.FINE, "Keycloakvalidate set to true");
-				json.put("keycloakValidate", true);
-				JSONObject validate = json.getJSONObject("keycloakValidate");
+				keycloak.put("keycloakValidate", true);
+				JSONObject validate = keycloakData.getJSONObject("keycloakValidate");
 				if (validate.containsKey("keycloakRespectAccessTokenTimeout")) {
-					json.put("keycloakRespectAccessTokenTimeout", validate.getBoolean("keycloakRespectAccessTokenTimeout"));
+					keycloak.put("keycloakRespectAccessTokenTimeout", validate.getBoolean("keycloakRespectAccessTokenTimeout"));
 					LOGGER.log(Level.FINE, "Respect access token timeout is set to " + validate.getBoolean("keycloakRespectAccessTokenTimeout"));
 				}
 			} else {
-				json.put("keycloakValidate", false);
-				json.put("keycloakRespectAccessTokenTimeout", true);
+				keycloak.put("keycloakValidate", false);
+				keycloak.put("keycloakRespectAccessTokenTimeout", true);
 			}
-			return super.newInstance(req, json);
+			return super.newInstance(req, keycloak);
 		}
 
 		@Restricted(NoExternalUse.class) // Only for loading in from legacy disk

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -38,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.base.Strings;
+import hudson.model.Descriptor.FormException;
 import jenkins.security.SecurityListener;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.AuthenticationException;
@@ -383,7 +384,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 		}
 
 		@Override
-		public boolean configure(StaplerRequest req, JSONObject json) throws hudson.model.Descriptor.FormException {
+		public SecurityRealm newInstance(StaplerRequest req, JSONObject json) throws FormException {
 			json = json.getJSONObject("keycloak");
 			// if json contains keycloakvalidate then keycloakvalidate is true
 			if (json.containsKey("keycloakValidate")) {
@@ -398,7 +399,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 				json.put("keycloakValidate", false);
 				json.put("keycloakRespectAccessTokenTimeout", true);
 			}
-			return super.configure(req, json);
+			return super.newInstance(req, json);
 		}
 
 		@Restricted(NoExternalUse.class) // Only for loading in from legacy disk

--- a/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/KeycloakSecurityRealm/config.jelly
@@ -1,6 +1,3 @@
-<!--
-
--->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:section title="Global Keycloak Settings" name="keycloak" >


### PR DESCRIPTION
Abnormal phenomenon
1. After filling out the Settings on the KeyCloak configuration screen, the contents cannot be loaded when the cloak configuration page is reopened, and there is no configuration information in the configuration file (config.xml)

2. If the configuration file has previous configuration information(config.xml), the configuration page can be displayed correctly when you reopen it

To improve the
1. upgrade jenkins.version=2.263.1
2. add jenkins dependencyManagement pom
3. Fix the problem above
