### PR TITLE
[SECURITY-2986] Add verification check for state parameter that comes back during finish login request.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,10 @@
-// Builds a module using https://github.com/jenkins-infra/pipeline-library
-// Requirements:
-//   - agents with label 'linux' and 'windows'
-//   - tools with label 'jdk8' and 'mvn'
-//   - latest Pipeline plugins, 'Timestamper' plugin
-//   - recommended to use this Jenkinsfile with 'Multibranch Pipeline' plugin
-
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+/*
+ * Standard from https://github.com/jenkins-infra/pipeline-library/
+ */
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
 		<keycloak.version>20.0.2</keycloak.version>
 		<jenkins.version>2.361.1</jenkins.version>
 		<log4j.version>1.7.26</log4j.version>
-		<java.level>11</java.level>
 		<configuration-as-code.version>1569.vb_72405b_80249</configuration-as-code.version>
 		<jackson.version>2.13.4</jackson.version>
 		<jackson.databind.version>2.13.4.2</jackson.databind.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>4.0</version>
+		<version>4.54</version>
 	</parent>
 
 	<artifactId>keycloak</artifactId>
@@ -23,12 +23,13 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<keycloak.version>13.0.0</keycloak.version>
-		<jenkins.version>2.190.1</jenkins.version>
+		<keycloak.version>20.0.2</keycloak.version>
+		<jenkins.version>2.361.1</jenkins.version>
 		<log4j.version>1.7.26</log4j.version>
-		<java.level>8</java.level>
-		<configuration-as-code.version>1.36</configuration-as-code.version>
-		<jackson.version>2.12.2</jackson.version>
+		<java.level>11</java.level>
+		<configuration-as-code.version>1569.vb_72405b_80249</configuration-as-code.version>
+		<jackson.version>2.13.4</jackson.version>
+		<jackson.databind.version>2.13.4.2</jackson.databind.version>
 	</properties>
 
 	<licenses>
@@ -121,7 +122,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+			<version>${jackson.databind.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.jenkins</groupId>


### PR DESCRIPTION
The state parameter was being added to the keycloak request but was not being verified on redirect back to jenkins. This PR adds in a check to make sure that state value matches when it comes back to prevent CSRF attacks.

Also some dependencies had outstading CVEs against them so updated them to _newer_ versions but still ~6 months old or older for better compatibility. 

### Testing done

Tested on jenkins system by:
1) Performing a normal login and check logs for message indicating successful state check
2) Interrupting the login flow, replacing state parameter on redirect call, and verifying that browser was not able to log in and was redirected back to login page.
### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
