### PR TITLE
[JENKINS-71352] Convert to use spring security instead of acegi security.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/KeycloakAuthentication.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAuthentication.java
@@ -2,24 +2,26 @@ package org.jenkinsci.plugins;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
 import hudson.security.SecurityRealm;
 
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.GrantedAuthorityImpl;
-import org.acegisecurity.providers.AbstractAuthenticationToken;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.IDToken;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 /**
  * 
  * @author Mohammad Nadeem
  * @author dev.lauer@elnarion.de
  *
  */
-public class KeycloakAuthentication extends AbstractAuthenticationToken  {
+public class KeycloakAuthentication extends AbstractAuthenticationToken {
 
 
 	private static final long serialVersionUID = 1L;
@@ -45,30 +47,29 @@ public class KeycloakAuthentication extends AbstractAuthenticationToken  {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static GrantedAuthority[] buildRoles(AccessToken accessToken, String resourceName) {
-		List<GrantedAuthority> roles;
-		roles = new ArrayList<GrantedAuthority>();
+	private static Collection<GrantedAuthority> buildRoles(AccessToken accessToken, String resourceName) {
+		List<GrantedAuthority> roles = new ArrayList<>();
 
 		if (accessToken != null && accessToken.getRealmAccess() != null) {
 			for (String role : accessToken.getRealmAccess().getRoles()) {
-				roles.add(new GrantedAuthorityImpl(role));
+				roles.add(new SimpleGrantedAuthority(role));
 			}
 		}
 
 		if(accessToken != null && accessToken.getOtherClaims().containsKey("roles")) {
 			for(String role : (List<String>) accessToken.getOtherClaims().get("roles")) {
-				roles.add(new GrantedAuthorityImpl(role));
+				roles.add(new SimpleGrantedAuthority(role));
 			}
 		}
 
 		if (accessToken != null && accessToken.getResourceAccess().containsKey(resourceName)) {
 			for (String role : accessToken.getResourceAccess().get(resourceName).getRoles()) {
-				roles.add(new GrantedAuthorityImpl(role));
+				roles.add(new SimpleGrantedAuthority(role));
 			}
 		}
 
-		roles.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
-		return roles.toArray(new GrantedAuthority[roles.size()]);
+		roles.add(SecurityRealm.AUTHENTICATED_AUTHORITY2);
+		return roles;
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -37,14 +37,8 @@ import javax.security.cert.X509Certificate;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
-import com.google.common.base.Strings;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.security.SecurityListener;
-import org.acegisecurity.Authentication;
-import org.acegisecurity.AuthenticationException;
-import org.acegisecurity.AuthenticationManager;
-import org.acegisecurity.BadCredentialsException;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.OAuth2Constants;
@@ -65,10 +59,7 @@ import org.keycloak.representations.IDToken;
 import org.keycloak.representations.adapters.config.AdapterConfig;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
@@ -76,6 +67,7 @@ import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 
 import hudson.Extension;
@@ -85,6 +77,10 @@ import hudson.security.SecurityRealm;
 import hudson.tasks.Mailer;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  *
@@ -202,7 +198,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
             builder.queryParam("kc_idp_hint", keycloakIdp);
         }
 		String authUrl = builder.build().toString();
-		request.getSession().setAttribute(AUTH_REQUESTED, Boolean.valueOf(true));
+		request.getSession().setAttribute(AUTH_REQUESTED, Boolean.TRUE);
 		request.getSession().setAttribute(OAuth2Constants.STATE, state);
 		createFilter();
 		return new HttpRedirect(authUrl);
@@ -280,7 +276,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 					KeycloakUserDetails userDetails = new KeycloakUserDetails(
 							idToken.getPreferredUsername(), auth.getAuthorities()
 					);
-					SecurityListener.fireAuthenticated(userDetails);
+					SecurityListener.fireAuthenticated2(userDetails);
 				}
 			}
 

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -367,7 +367,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 				LOGGER.log(Level.SEVERE, "Logout Exception ", e);
 			}
 		}
-		req.getSession().setAttribute(AUTH_REQUESTED, Boolean.valueOf(false));
+		req.getSession().setAttribute(AUTH_REQUESTED, Boolean.FALSE);
 		super.doLogout(req, rsp);
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/KeycloakUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakUserDetails.java
@@ -23,10 +23,12 @@
  */
 package org.jenkinsci.plugins;
 
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.userdetails.User;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
 
 /**
  * The Class KeycloakUserDetails.
@@ -48,7 +50,7 @@ public class KeycloakUserDetails extends User {
 	 * @param authorities the authorities
 	 * @throws IllegalArgumentException the illegal argument exception
 	 */
-    public KeycloakUserDetails(String username, GrantedAuthority[] authorities) throws IllegalArgumentException {
+    public KeycloakUserDetails(String username, Collection<GrantedAuthority> authorities) throws IllegalArgumentException {
         super(username, "", true, true, true, true, authorities);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/RefreshFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/RefreshFilter.java
@@ -150,7 +150,7 @@ public class RefreshFilter implements Filter {
 	private void redirectToJenkinsLogoutUrl(ServletResponse res) throws IOException {
 		//reset everything done before and redirect
 		res.reset();
-		Jenkins j = Jenkins.getActiveInstance();
+		Jenkins j = Jenkins.get();
 		HttpServletResponse httpRes = (HttpServletResponse) res;
 		LOGGER.log(Level.INFO, "KeycloakFilter logout requested");
 		String rootURL = j.getRootUrl();

--- a/src/main/java/org/jenkinsci/plugins/RefreshFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/RefreshFilter.java
@@ -16,9 +16,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.acegisecurity.Authentication;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 import org.keycloak.adapters.KeycloakDeployment;
 import org.keycloak.adapters.ServerRequest;
 import org.keycloak.adapters.ServerRequest.HttpFailure;
@@ -26,6 +23,9 @@ import org.keycloak.representations.AccessTokenResponse;
 
 import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * Filter to check the validity of the token
@@ -65,36 +65,34 @@ public class RefreshFilter implements Filter {
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
 			throws IOException, ServletException {
 		LOGGER.log(Level.FINER, "KeycloakFilter entered");
-		Jenkins j = Jenkins.getActiveInstance();
-		if (j != null) {
-			SecurityRealm sr = j.getSecurityRealm();
-			if (sr != null) {
-				// only if an instance of KeycloakSecurityRealm is active check token validity
-				if (sr instanceof KeycloakSecurityRealm) {
-					KeycloakSecurityRealm ksr = (KeycloakSecurityRealm) sr;
-					LOGGER.log(Level.FINER, "KeycloakSecurityRealm found");
-					boolean checkTokenValidity = ksr.checkKeycloakOnEachRequest();
-					HttpServletRequest httpRequest = (HttpServletRequest) req;
-					HttpSession session = httpRequest.getSession();
-					Boolean authRequestedAttribute = (Boolean) session
-							.getAttribute(KeycloakSecurityRealm.AUTH_REQUESTED);
-					boolean authenticationRequested = (authRequestedAttribute == null) ? false
-							: authRequestedAttribute.booleanValue();
-					boolean skipUrl = skipUrl(httpRequest);
-					LOGGER.log(Level.FINEST,
-							"RequestPath" + httpRequest.getPathInfo() + " skipUrl" + skipUrl
-									+ " AuthenticationRequested" + authenticationRequested + " CheckRequest"
-									+ checkTokenValidity);
-					// only if a check is configured and the user already logged in and the
-					// requested URL does not end with logout do filtering
-					if (checkTokenValidity && !skipUrl && authenticationRequested) {
-						boolean tokeninvalid = checkTokenValidity(res, ksr);
-						if (tokeninvalid)
-							return;
-					}
-					// normal processing
-					chain.doFilter(req, res);
+		Jenkins j = Jenkins.get();
+		SecurityRealm sr = j.getSecurityRealm();
+		if (sr != null) {
+			// only if an instance of KeycloakSecurityRealm is active check token validity
+			if (sr instanceof KeycloakSecurityRealm) {
+				KeycloakSecurityRealm ksr = (KeycloakSecurityRealm) sr;
+				LOGGER.log(Level.FINER, "KeycloakSecurityRealm found");
+				boolean checkTokenValidity = ksr.checkKeycloakOnEachRequest();
+				HttpServletRequest httpRequest = (HttpServletRequest) req;
+				HttpSession session = httpRequest.getSession();
+				Boolean authRequestedAttribute = (Boolean) session
+						.getAttribute(KeycloakSecurityRealm.AUTH_REQUESTED);
+				boolean authenticationRequested = (authRequestedAttribute == null) ? false
+						: authRequestedAttribute.booleanValue();
+				boolean skipUrl = skipUrl(httpRequest);
+				LOGGER.log(Level.FINEST,
+						"RequestPath" + httpRequest.getPathInfo() + " skipUrl" + skipUrl
+								+ " AuthenticationRequested" + authenticationRequested + " CheckRequest"
+								+ checkTokenValidity);
+				// only if a check is configured and the user already logged in and the
+				// requested URL does not end with logout do filtering
+				if (checkTokenValidity && !skipUrl && authenticationRequested) {
+					boolean tokeninvalid = checkTokenValidity(res, ksr);
+					if (tokeninvalid)
+						return;
 				}
+				// normal processing
+				chain.doFilter(req, res);
 			}
 		}
 	}

--- a/src/test/java/org/jenkinsci/plugins/KeycloakSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/KeycloakSecurityRealmTest.java
@@ -39,7 +39,7 @@ public class KeycloakSecurityRealmTest {
     public void export_casc_keycloak() throws Exception {
         KeycloakSecurityRealm ksr = new KeycloakSecurityRealm();
         ksr.setKeycloakJson("{\"realm\": \"master\",\"auth-server-url\": \"https://keycloak.example.com/auth/\",\"ssl-required\": \"external\",\"resource\": \"ci-example-com\",\"credentials\": {\"secret\": \"secret-secret-secret\"},\"confidential-port\": 0}");
-		Jenkins.getInstanceOrNull().setSecurityRealm(ksr);
+		Jenkins.get().setSecurityRealm(ksr);
 
         ConfiguratorRegistry registry = ConfiguratorRegistry.get();
         ConfigurationContext context = new ConfigurationContext(registry);

--- a/src/test/java/org/jenkinsci/plugins/KeycloakSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/KeycloakSecurityRealmTest.java
@@ -21,7 +21,7 @@ public class KeycloakSecurityRealmTest {
     @Test
     @ConfiguredWithCode("casc.yaml")
     public void configure_keycloak() {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         final KeycloakSecurityRealm securityRealm = (KeycloakSecurityRealm) jenkins.getSecurityRealm();
         assertEquals("{\n" +
 			"  \"realm\": \"master\",\n" +


### PR DESCRIPTION
Replaced deprecated acegi classes with spring security. Part of JEP-227.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
