### PR TITLE
Add avatar / OpenID picture claim support

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
@@ -1,0 +1,78 @@
+package org.jenkinsci.plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.User;
+import hudson.model.UserProperty;
+import hudson.model.UserPropertyDescriptor;
+
+public class KeycloakAvatarProperty extends UserProperty {
+
+    private final AvatarImage avatarImage;
+
+    public KeycloakAvatarProperty(AvatarImage avatarImage) {
+        this.avatarImage = avatarImage;
+    }
+
+    public String getAvatarUrl() {
+        if (isHasAvatar()) {
+            return getAvatarImageUrl();
+        }
+        return null;
+    }
+
+    private String getAvatarImageUrl() {
+        return avatarImage.url;
+    }
+
+    public boolean isHasAvatar() {
+        return avatarImage != null && avatarImage.isValid();
+    }
+
+    public String getDisplayName() {
+        return "Keycloak Avatar";
+    }
+
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return "keycloak-avatar";
+    }
+
+    @Extension
+    public static class DescriptorImpl extends UserPropertyDescriptor {
+
+        @Override
+        @NonNull
+        public String getDisplayName() {
+            return "Keycloak Avatar";
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public UserProperty newInstance(User user) {
+            return new KeycloakAvatarProperty(null);
+        }
+    }
+
+    /**
+     * Keycloak avatar is the standard picture field on the profile claim.
+     */
+    public static class AvatarImage {
+        private final String url;
+
+        public AvatarImage(String url) {
+            this.url = url;
+        }
+
+        public boolean isValid() {
+            return url != null;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/KeycloakAvatarResolver.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAvatarResolver.java
@@ -1,0 +1,20 @@
+
+package org.jenkinsci.plugins;
+
+import hudson.Extension;
+import hudson.model.User;
+import hudson.tasks.UserAvatarResolver;
+
+@Extension
+public class KeycloakAvatarResolver extends UserAvatarResolver {
+    @Override
+    public String findAvatarFor(User user, int width, int height) {
+        if (user != null) {
+            KeycloakAvatarProperty avatarProperty = user.getProperty(KeycloakAvatarProperty.class);
+            if (avatarProperty != null) {
+                return avatarProperty.getAvatarUrl();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -38,6 +38,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.security.SecurityListener;
 import org.apache.commons.lang.StringUtils;
 import org.keycloak.KeycloakSecurityContext;
@@ -234,6 +235,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 	 * @return {@link HttpResponse} the response
 	 * @throws IOException
 	 */
+	@SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "We want to catch all exceptions")
 	public HttpResponse doFinishLogin(StaplerRequest request) throws IOException {
 
 		String redirect = redirectUrl(request);
@@ -271,6 +273,15 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 
 					if (!currentUser.getProperty(Mailer.UserProperty.class).hasExplicitlyConfiguredAddress()) {
 						currentUser.addProperty(new Mailer.UserProperty(idToken.getEmail()));
+					}
+
+					// Set picture/avatar if present
+					String avatarUrl = idToken.getPicture();
+					if (avatarUrl != null) {
+						LOGGER.finest("Avatar url is: " + avatarUrl);
+						KeycloakAvatarProperty.AvatarImage avatarImage = new KeycloakAvatarProperty.AvatarImage(avatarUrl);
+						KeycloakAvatarProperty keycloakAvatarProperty = new KeycloakAvatarProperty(avatarImage);
+						currentUser.addProperty(keycloakAvatarProperty);
 					}
 
 					KeycloakUserDetails userDetails = new KeycloakUserDetails(


### PR DESCRIPTION
This PR add support for Jenkins avatar exention `UserAvatarResolver`

Open ID support the "picture" field (An URL) as part of the profile claim. Using keycloak library it's available using `String avatarUrl = idToken.getPicture();`

### Testing done

Interactive tests using a keycloak and my user with a picture URL

See

![keycloak_avatar](https://github.com/user-attachments/assets/a29a8581-31ee-4a3b-a3d7-d0aa989dfcc8)
![keycloak_avatar2](https://github.com/user-attachments/assets/e7cd6f2e-43d3-4077-bc60-1995558bd108)

More recent Jenkins version should display the avatar better (fixed by https://github.com/jenkinsci/jenkins/pull/10180)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
