### PR TITLE
[JENKINS-76303] Allow showing user avatars when CSP is enforced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 			<groupId>org.kohsuke</groupId>
 			<artifactId>access-modifier-suppressions</artifactId>
-			<version>1.35</version>
+			<version>${access-modifier-checker.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,6 @@
 		<!-- TODO https://github.com/jenkinsci/jenkins/pull/11269 -->
 		<jenkins.version>2.537-rc37714.d5718019b_8ff</jenkins.version>
 		<hpi.compatibleSinceVersion>2.3.1</hpi.compatibleSinceVersion>
-
-		<!-- AvatarContributor in KeycloakAvatarProperty; SuppressRestrictedWarnings doesn't work -->
-		<useBeta>true</useBeta>
 	</properties>
 
 	<licenses>
@@ -136,6 +133,12 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>jackson2-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.kohsuke</groupId>
+			<artifactId>access-modifier-suppressions</artifactId>
+			<version>1.35</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,12 @@
 		<keycloak.version>20.0.3</keycloak.version>
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.452</jenkins.baseline>
-		<jenkins.version>${jenkins.baseline}.4</jenkins.version>
+		<!-- TODO https://github.com/jenkinsci/jenkins/pull/11269 -->
+		<jenkins.version>2.537-rc37714.d5718019b_8ff</jenkins.version>
 		<hpi.compatibleSinceVersion>2.3.1</hpi.compatibleSinceVersion>
+
+		<!-- AvatarContributor in KeycloakAvatarProperty; SuppressRestrictedWarnings doesn't work -->
+		<useBeta>true</useBeta>
 	</properties>
 
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,7 @@
 		<keycloak.version>20.0.3</keycloak.version>
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.452</jenkins.baseline>
-		<!-- TODO https://github.com/jenkinsci/jenkins/pull/11269 -->
-		<jenkins.version>2.537-rc37714.d5718019b_8ff</jenkins.version>
+		<jenkins.version>2.539</jenkins.version>
 		<hpi.compatibleSinceVersion>2.3.1</hpi.compatibleSinceVersion>
 	</properties>
 

--- a/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
@@ -5,6 +5,7 @@ import hudson.Extension;
 import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
+import jenkins.security.csp.AvatarContributor;
 
 public class KeycloakAvatarProperty extends UserProperty {
 
@@ -69,10 +70,16 @@ public class KeycloakAvatarProperty extends UserProperty {
 
         public AvatarImage(String url) {
             this.url = url;
+            AvatarContributor.allow(url);
         }
 
         public boolean isValid() {
             return url != null;
+        }
+
+        private Object readResolve() {
+            AvatarContributor.allow(url);
+            return this;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakAvatarProperty.java
@@ -6,6 +6,7 @@ import hudson.model.User;
 import hudson.model.UserProperty;
 import hudson.model.UserPropertyDescriptor;
 import jenkins.security.csp.AvatarContributor;
+import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 public class KeycloakAvatarProperty extends UserProperty {
 
@@ -65,6 +66,7 @@ public class KeycloakAvatarProperty extends UserProperty {
     /**
      * Keycloak avatar is the standard picture field on the profile claim.
      */
+    @SuppressRestrictedWarnings(AvatarContributor.class)
     public static class AvatarImage {
         private final String url;
 


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-76303

Adapt to https://github.com/jenkinsci/jenkins/pull/11269 by allowing the domain hosting avatars as `img-src` in CSP.

### Testing done

None. Plugin doesn't even compile for me, neither JDK 17 nor 21. Same error as in the PR build.

A basic interactive test with `mvn hpi:run` should allow confirming this works; as CSP is enforced in this mode.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
