### PR TITLE
Remove usages of Commons Lang 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>5.28</version>
+		<version>6.2211.v27f680c93c53</version>
 		<relativePath />
 	</parent>
 
@@ -34,6 +34,7 @@
 		<jenkins.baseline>2.504</jenkins.baseline>
 		<jenkins.version>2.539</jenkins.version>
 		<hpi.compatibleSinceVersion>2.3.1</hpi.compatibleSinceVersion>
+		<ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
 	</properties>
 
 	<licenses>

--- a/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/KeycloakSecurityRealm.java
@@ -26,6 +26,7 @@ THE SOFTWARE.
  */
 package org.jenkinsci.plugins;
 
+import java.util.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -40,7 +41,6 @@ import javax.servlet.http.HttpServletRequest;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jenkins.security.SecurityListener;
-import org.apache.commons.lang.StringUtils;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.adapters.AdapterDeploymentContext;
@@ -130,7 +130,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 	@DataBoundConstructor
 	public KeycloakSecurityRealm(String keycloakIdp, String keycloakJson, boolean keycloakValidate, boolean keycloakRespectAccessTokenTimeout) throws IOException {
 		super();
-		if (StringUtils.isEmpty(keycloakJson)) {
+		if (keycloakJson == null || keycloakJson.isEmpty()) {
 			throw new IllegalArgumentException("Keycloak JSON is a mandatory item.");
 		}
 		setKeycloakIdp(keycloakIdp);
@@ -325,13 +325,13 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 	}
 
 	private void checkState(String queryState, Object sessionStateObj) {
-		if (StringUtils.isEmpty(queryState) || sessionStateObj == null) {
+		if (queryState == null || queryState.isEmpty() || sessionStateObj == null) {
 			LOGGER.log(Level.WARNING, "Cannot validate incoming authentication attempt due to state not being found. State from query: "
 				+ queryState + " State from session: " + sessionStateObj);
 			throw new AuthenticationServiceException("Could not validate state token during authentication.");
 		}
 		String sessionState = sessionStateObj.toString();
-		if (StringUtils.equals(queryState, sessionState)) {
+		if (Objects.equals(queryState, sessionState)) {
 			LOGGER.log(Level.FINE, "State cookie matches parameter value.");
 		} else {
 			LOGGER.log(Level.WARNING, "State session value (" + sessionState + ") did NOT match parameter value (" + queryState + ")");
@@ -410,7 +410,7 @@ public class KeycloakSecurityRealm extends SecurityRealm {
 		*/
 		public FormValidation doCheckKeycloakJson(@QueryParameter String value) throws ServletException {
 			try {
-				if (StringUtils.isNotEmpty(value)) {
+				if (value != null && !value.isEmpty()) {
 					JsonSerialization.readValue(value, AdapterConfig.class);
 				} else {
 					return FormValidation.error("Keycloak JSON is required.");


### PR DESCRIPTION
No need to depend on a third-party library here when the Java Platform provides this
functionality natively.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `KeycloakSecurityRealm`: `StringUtils.isEmpty` / `isNotEmpty` become plain `String` checks and
  `StringUtils.equals` becomes `Objects.equals`. No dependency was added — this plugin did not
  declare Commons Lang, it came in transitively from core.
- Bumped the parent POM to `6.2211.v27f680c93c53` so the `ban-commons-lang-2` enforcer rule is
  available, and enabled it.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
