### PR TITLE
Fix startup crash: bundle keycloak-policy-enforcer and align keycloak-authz-client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<keycloak.version>25.0.3</keycloak.version>
-		<!-- authz client on own release schedule -->
-		<keycloak.authz.client.version>26.0.7</keycloak.authz.client.version>
+		<!--
+			Kept in lock-step with keycloak.version. keycloak-authz-client 26.x ships
+			its own org.keycloak.common.crypto.CryptoProvider (AuthzClientCryptoProvider)
+			which collides with keycloak-crypto-default's DefaultCryptoProvider, making
+			CryptoIntegration.detectProvider() throw
+			"Multiple crypto providers loaded" when the deployment is built.
+		-->
+		<keycloak.authz.client.version>${keycloak.version}</keycloak.authz.client.version>
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.504</jenkins.baseline>
 		<jenkins.version>2.539</jenkins.version>
@@ -156,6 +162,33 @@
 			<groupId>org.keycloak</groupId>
 			<artifactId>keycloak-adapter-spi</artifactId>
 			<version>${keycloak.version}</version>
+		</dependency>
+		<!--
+			keycloak-adapter-core's KeycloakDeployment references
+			org.keycloak.adapters.authorization.PolicyEnforcer, which lives in this
+			separate artifact. Without it Jenkins/Stapler fails to reflect over the
+			security realm (NoClassDefFoundError: org/keycloak/adapters/authorization/PolicyEnforcer)
+			while rendering the login page.
+		-->
+		<dependency>
+			<groupId>org.keycloak</groupId>
+			<artifactId>keycloak-policy-enforcer</artifactId>
+			<version>${keycloak.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.wildfly.security</groupId>
+					<artifactId>wildfly-elytron-http-oidc</artifactId>
+				</exclusion>
+				<!-- provided by jackson2-api-->
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
`master` does not start on a current Jenkins. Two independent dependency problems:

### 1. `NoClassDefFoundError: org/keycloak/adapters/authorization/PolicyEnforcer`

Rendering the login page throws:

```
java.lang.NoClassDefFoundError: org/keycloak/adapters/authorization/PolicyEnforcer
  at jenkins.security.stapler.TypedFilter.isSpecificClassStaplerRelevant(TypedFilter.java:84)
  ...
  at org.kohsuke.stapler.jelly.IncludeTag.doTag(IncludeTag.java:135)   (lib/layout/header/login.jelly)
```

Stapler reflects over `KeycloakSecurityRealm` and has to resolve
`KeycloakDeployment.getPolicyEnforcer()`, whose type lives in the separate
`keycloak-policy-enforcer` artifact that `keycloak-adapter-core` does **not**
pull transitively. This PR adds it (`${keycloak.version}`), excluding
`wildfly-elytron-http-oidc` and the jackson deps already provided by
`jackson2-api`.

### 2. `IllegalStateException: Multiple crypto providers loaded`

Once #1 is fixed, building the deployment throws:

```
java.lang.IllegalStateException: Multiple crypto providers loaded with the classLoader ...
  Available providers: [org.keycloak.authorization.client.util.crypto.AuthzClientCryptoProvider,
                        org.keycloak.crypto.def.DefaultCryptoProvider]
  at org.keycloak.common.crypto.CryptoIntegration.detectProvider(CryptoIntegration.java:61)
  at org.keycloak.adapters.KeycloakDeploymentBuilder.build(KeycloakDeploymentBuilder.java:212)
```

`keycloak-authz-client` was pinned to `26.0.7` while the rest of the adapter is
`25.0.3`. authz-client 26.x (via `keycloak-client-common-synced`) registers its
own `org.keycloak.common.crypto.CryptoProvider`, which collides with
`keycloak-crypto-default`'s. This PR tracks `keycloak.version` for authz-client
so there is exactly one provider on the classpath.

### Compatibility

No functional/config change — dependency alignment only. `mvn clean verify`
green (tests, enforcer, spotbugs, access-modifier-checker). Manually verified a
built `.hpi` now starts and renders the login page on Jenkins 2.568.
